### PR TITLE
Update path to netsh i Windows

### DIFF
--- a/common.go
+++ b/common.go
@@ -695,7 +695,7 @@ func configureWindows(interfaceName string, ip net.IP, ipNet *net.IPNet) error {
 	maskIP := net.IP(mask)
 
 	// Set the IP address using netsh
-	cmd := exec.Command("netsh", "interface", "ipv4", "set", "address",
+	cmd := exec.Command("C:\\Windows\\System32\\netsh.exe", "interface", "ipv4", "set", "address",
 		fmt.Sprintf("name=%s", interfaceName),
 		"source=static",
 		fmt.Sprintf("addr=%s", ip.String()),


### PR DESCRIPTION
Win11 reporting:
"ERROR: 2025/08/26 09:38:55 Failed to configure interface: netsh command failed: exec: "netsh": cannot run executable found relative to current directory, output:"

--
Ref: 
indicates a security measure implemented in Go 1.19 and later versions, affecting how executables are resolved via the system's PATH environment variable. Specifically, the os/exec package in Go will no longer resolve a program using an implicit or explicit path entry relative to the current directory (e.g., ./go on Unix or .\go.exe on Windows), even if the PATH is configured to allow it.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description


## How to test?

