### PR TITLE
Fix UDP port conflict during NAT holepunching on macOS

### DIFF
--- a/main.go
+++ b/main.go
@@ -537,7 +537,8 @@ func runOlmMainWithArgs(ctx context.Context, args []string) {
 		close(stopHolepunch)
 
 		// wait 10 milliseconds to ensure the previous connection is closed
-		time.Sleep(200 * time.Millisecond)
+		logger.Debug("Waiting 500 milliseconds to ensure previous connection is closed")
+		time.Sleep(500 * time.Millisecond)
 
 		// if there is an existing tunnel then close it
 		if dev != nil {

--- a/main.go
+++ b/main.go
@@ -537,7 +537,7 @@ func runOlmMainWithArgs(ctx context.Context, args []string) {
 		close(stopHolepunch)
 
 		// wait 10 milliseconds to ensure the previous connection is closed
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 
 		// if there is an existing tunnel then close it
 		if dev != nil {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Fixes #16 - UDP port conflict during NAT holepunching on macOS

This PR resolves a race condition where the holepunch goroutine was still holding a UDP port when WireGuard attempted to bind to it, causing "address already in use" errors and forcing unnecessary fallbacks to relay mode.

The fix increases the delay after `close(stopHolepunch)` from 10ms to 500ms in `main.go`, giving macOS sufficient time to release the UDP port before WireGuard initialization.

## How to test?
1. Run olm with holepunch enabled on macOS:
   ```bash
   sudo -E olm --holepunch
   ```

2. Check the logs - you should see successful connection without port errors:
   ```
   INFO: WireGuard device created.
   INFO: Peer 1 is now connected (RTT: ~70ms)
   ```

3. Verify direct connection (not relay) with:
   ```bash
   sudo wg show
   ```
   The endpoint should show the peer's actual IP (e.g., `1.2.3.4:65456`) not the relay server IP.

4. Without this fix, you would see:
   ```
   ERROR: Failed to bring up WireGuard device: listen udp4 :XXXXX: bind: address already in use
   INFO: Adjusted peer 1 to point to relay!
   ```