### PR TITLE
added docker version of olm

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,6 +14,18 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKER_HUB_USERNAME }}
+                  password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
             - name: Extract tag name
               id: get-tag
               run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -32,6 +44,10 @@ jobs:
                   else
                     echo "main.go not found"
                   fi
+            - name: Build and push Docker images
+              run: |
+                  TAG=${{ env.TAG }}
+                  make docker-build-release tag=$TAG
 
             - name: Build binaries
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Build go
         run: go build
 
+      - name: Build Docker image
+        run: make build
+
       - name: Build binaries
         run: make go-build-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /olm
 
 # Start a new stage from scratch
-FROM ubuntu:24.04 AS runner
+FROM alpine:3.22 AS runner
 
-RUN apt-get update && apt-get install ca-certificates -y  && rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add ca-certificates
 
 # Copy the pre-built binary file from the previous stage and the entrypoint script
 COPY --from=builder /olm /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
 
 all: go-build-release 
 
+docker-build-release:
+	@if [ -z "$(tag)" ]; then \
+		echo "Error: tag is required. Usage: make docker-build-release tag=<tag>"; \
+		exit 1; \
+	fi
+	docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 -t fosrl/olm:latest -f Dockerfile --push .
+	docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 -t fosrl/olm:$(tag) -f Dockerfile --push .
+
 local: 
 	CGO_ENABLED=0 go build -o olm
+
+build:
+	docker build -t fosrl/olm:latest .
 
 go-build-release:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/olm_linux_arm64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  olm:
+    image: fosrl/olm:latest
+    container_name: olm
+    restart: unless-stopped
+    environment:
+      - PANGOLIN_ENDPOINT=https://example.com
+      - OLM_ID=vdqnz8rwgb95cnp 
+      - OLM_SECRET=1sw05qv1tkfdb1k81zpw05nahnnjvmhxjvf746umwagddmdg 
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    network_mode: host


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
- Updated Dockerfile to use Apline to reduce image size by 80%.
- Added docker build to CICD and Makefile
- Added docker-compose.yml as example

`network_mode: host` brings the olm network interface to the host system.

I am not sure why i need `devices: - /dev/net/tun:/dev/net/tun`, but without i am getting error that the container has no access to `/dev/net/tun`. Dont understand why Newt and Gerbil are working without.

fixes https://github.com/fosrl/olm/issues/18
