### PR TITLE
fix: add ipv6 endpoint formatter

### DIFF
--- a/peermonitor/peermonitor.go
+++ b/peermonitor/peermonitor.go
@@ -216,7 +216,7 @@ func (pm *PeerMonitor) HandleFailover(siteID int, relayEndpoint string) {
 public_key=%s
 allowed_ip=%s/32
 endpoint=%s:21820
-persistent_keepalive_interval=1`, pm.privateKey, config.PublicKey, config.ServerIP, formattedEndpoint) // Use the correctly formatted endpoint here
+persistent_keepalive_interval=1`, pm.privateKey, config.PublicKey, config.ServerIP, formattedEndpoint)
 
 	err := pm.device.IpcSet(wgConfig)
 	if err != nil {

--- a/peermonitor/peermonitor.go
+++ b/peermonitor/peermonitor.go
@@ -3,6 +3,7 @@ package peermonitor
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -204,12 +205,18 @@ func (pm *PeerMonitor) HandleFailover(siteID int, relayEndpoint string) {
 		return
 	}
 
+    // Check for IPv6 and format the endpoint correctly
+    formattedEndpoint := relayEndpoint
+    if strings.Contains(relayEndpoint, ":") {
+        formattedEndpoint = fmt.Sprintf("[%s]", relayEndpoint)
+    }
+
 	// Configure WireGuard to use the relay
 	wgConfig := fmt.Sprintf(`private_key=%s
 public_key=%s
 allowed_ip=%s/32
 endpoint=%s:21820
-persistent_keepalive_interval=1`, pm.privateKey, config.PublicKey, config.ServerIP, relayEndpoint)
+persistent_keepalive_interval=1`, pm.privateKey, config.PublicKey, config.ServerIP, formattedEndpoint) // Use the correctly formatted endpoint here
 
 	err := pm.device.IpcSet(wgConfig)
 	if err != nil {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

To resolve https://github.com/fosrl/olm/issues/25

## How to test?

I tested i by running `GOOS=linux GOARCH=amd64 go build .`, got the binary, replaced the one on my server and established connection from Olm to Pangolin relay (Gerbil) only via ipv6.

## Proof Of Work :
```
root@debian13-amd64:~# systemctl status olm --no-pager -l
● olm.service - Olm
     Loaded: loaded (/etc/systemd/system/olm.service; disabled; preset: enabled)
     Active: active (running) since Thu 2025-09-04 14:07:08 CEST; 6min ago
 Invocation: 95b9893a92304054bbffe49d194d6d4b
   Main PID: 2180396 (olm)
      Tasks: 16 (limit: 76567)
     Memory: 9.3M (peak: 10.8M)
        CPU: 83ms
     CGroup: /system.slice/olm.service
             └─2180396 /usr/local/bin/olm --id <redacted> --secret <redacted> --endpoint https://<redacted> --holepunch

Sep 04 14:07:08 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:08 Sent initial ping message
Sep 04 14:07:08 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:08 Starting hole punch for 1 exit nodes
Sep 04 14:07:08 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:08 Starting UDP hole punch to 1 exit nodes
Sep 04 14:07:08 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:08 Resolved exit node: <redacted> -> [<redacted>]:21820
Sep 04 14:07:09 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:09 Starting hole punch for 1 exit nodes
Sep 04 14:07:09 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:09 Stopping UDP holepunch for all exit nodes
Sep 04 14:07:09 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:09 UDP hole punch goroutine ended for all exit nodes
Sep 04 14:07:09 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:09 UDP hole punch goroutine ended
Sep 04 14:07:10 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:10 UAPI listener started
Sep 04 14:07:10 debian13-amd64 olm[2180396]: INFO: 2025/09/04 14:07:10 WireGuard device created.
```

Here you can see the ipv6 is in brackets and the wireguard tunnel is correctly establishing without error.