### PR TITLE
fix(ci): add back missing docker build local image rule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
         run: make go-build-release
 
       - name: Build Docker image
-        run: make docker-build-release
+        run: make docker-build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: local
 local:
 	CGO_ENABLED=0 go build -o ./bin/olm
 
+docker-build:
+	docker build -t fosrl/olm:latest .
+
 docker-build-release:
 	@if [ -z "$(tag)" ]; then \
 		echo "Error: tag is required. Usage: make docker-build-release tag=<tag>"; \


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Pull request CI has been broken for a minute, since the `docker-build-release` rule requires a tag.

This re-adds the docker local build Makefile rule and invokes it in CI instead of `docker-build-release`, since `docker buildx` isn't supported in the GitHub runners by default anyway.

## How to test?

CI should succeed properly without failing on the Docker build step every time.