### PR TITLE
dns/platform: prefer systemd-resolved when NSS routes through it

### DIFF
--- a/dns/platform/detect_unix.go
+++ b/dns/platform/detect_unix.go
@@ -11,7 +11,13 @@ import (
 	"github.com/fosrl/newt/logger"
 )
 
-const defaultResolvConfPath = "/etc/resolv.conf"
+const (
+	defaultResolvConfPath = "/etc/resolv.conf"
+	defaultNsswitchPath   = "/etc/nsswitch.conf"
+)
+
+// nsswitchPath is the file consulted by nsswitchPrefersResolved. Overridable for tests.
+var nsswitchPath = defaultNsswitchPath
 
 // DNSManagerType represents the type of DNS manager detected
 type DNSManagerType int
@@ -88,6 +94,68 @@ func (d DNSManagerType) String() string {
 	}
 }
 
+// nsswitchPrefersResolved reports whether /etc/nsswitch.conf routes hostname
+// lookups through systemd-resolved's NSS module (libnss_resolve) ahead of, or
+// to the exclusion of, the classic "dns" service that consults /etc/resolv.conf.
+//
+// This matters because on distributions whose default hosts line is
+//
+//	hosts: mymachines resolve [!UNAVAIL=return] files myhostname dns
+//
+// (common on Arch Linux and other systemd-forward distros), writing nameservers
+// to /etc/resolv.conf has no effect on resolution: NSS consults resolved first,
+// resolved returns NOTFOUND for an interface it knows nothing about, and the
+// [!UNAVAIL=return] action halts fallthrough to the dns service. In that case
+// we must register the DNS server with systemd-resolved via D-Bus for the
+// tunnel interface instead.
+func nsswitchPrefersResolved() bool {
+	data, err := os.ReadFile(nsswitchPath)
+	if err != nil {
+		return false
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "hosts:") {
+			continue
+		}
+
+		fields := strings.Fields(strings.TrimPrefix(trimmed, "hosts:"))
+
+		resolveIdx, dnsIdx := -1, -1
+		for i, f := range fields {
+			// Ignore action clauses like [!UNAVAIL=return] when locating services.
+			if strings.HasPrefix(f, "[") {
+				continue
+			}
+			switch f {
+			case "resolve":
+				if resolveIdx == -1 {
+					resolveIdx = i
+				}
+			case "dns":
+				if dnsIdx == -1 {
+					dnsIdx = i
+				}
+			}
+		}
+
+		if resolveIdx == -1 {
+			return false
+		}
+		// resolve is the sole DNS-facing service: it dominates.
+		if dnsIdx == -1 {
+			return true
+		}
+		// resolve consulted before dns: it answers first, and any halting action
+		// between them (e.g. [!UNAVAIL=return], [NOTFOUND=return]) prevents
+		// fallthrough on failure.
+		return resolveIdx < dnsIdx
+	}
+
+	return false
+}
+
 // DetectDNSManager combines file detection with runtime availability checks
 // to determine the best DNS configurator to use
 func DetectDNSManager(interfaceName string) DNSManagerType {
@@ -108,6 +176,15 @@ func DetectDNSManager(interfaceName string) DNSManagerType {
 	case NetworkManagerManager:
 		// Verify NetworkManager is actually running
 		if IsNetworkManagerAvailable() {
+			// If systemd-resolved is running and NSS is wired to consult it first,
+			// NetworkManager writing /etc/resolv.conf has no effect on resolution:
+			// NSS asks resolved first, resolved has no DNS configured for the tunnel
+			// interface and returns NOTFOUND, and [!UNAVAIL=return]-style actions
+			// halt fallthrough to the dns service. Register with resolved via D-Bus.
+			if IsSystemdResolvedAvailable() && nsswitchPrefersResolved() {
+				logger.Info("NetworkManager is running but NSS routes through systemd-resolved, using systemd-resolved configurator")
+				return SystemdResolvedManager
+			}
 			// Check if NetworkManager is delegating to systemd-resolved
 			if !IsNetworkManagerDNSModeSupported() {
 				logger.Info("NetworkManager is delegating DNS to systemd-resolved, using systemd-resolved configurator")
@@ -121,6 +198,13 @@ func DetectDNSManager(interfaceName string) DNSManagerType {
 		return FileManager
 
 	case ResolvconfManager:
+		// If NSS routes through systemd-resolved, writing /etc/resolv.conf via
+		// resolvconf will not affect hostname resolution — register DNS directly
+		// with resolved instead. See nsswitchPrefersResolved for rationale.
+		if IsSystemdResolvedAvailable() && nsswitchPrefersResolved() {
+			logger.Info("resolvconf is in use but NSS routes through systemd-resolved, using systemd-resolved configurator")
+			return SystemdResolvedManager
+		}
 		// Verify resolvconf is available
 		if IsResolvconfAvailable() {
 			return ResolvconfManager

--- a/dns/platform/detect_unix_test.go
+++ b/dns/platform/detect_unix_test.go
@@ -1,0 +1,86 @@
+//go:build (linux && !android) || freebsd
+
+package dns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNsswitchPrefersResolved(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "arch default with short-circuit",
+			content: "hosts: mymachines resolve [!UNAVAIL=return] files myhostname dns\n",
+			want:    true,
+		},
+		{
+			name:    "resolve before dns without action clause",
+			content: "hosts: files resolve dns\n",
+			want:    true,
+		},
+		{
+			name:    "resolve only, no dns",
+			content: "hosts: files resolve\n",
+			want:    true,
+		},
+		{
+			name:    "classic debian-style, dns only",
+			content: "hosts: files dns\n",
+			want:    false,
+		},
+		{
+			name:    "dns before resolve",
+			content: "hosts: files dns resolve\n",
+			want:    false,
+		},
+		{
+			name:    "neither resolve nor dns",
+			content: "hosts: files myhostname\n",
+			want:    false,
+		},
+		{
+			name:    "commented hosts line is ignored, real line wins",
+			content: "# hosts: files resolve dns\nhosts: files dns\n",
+			want:    false,
+		},
+		{
+			name:    "whitespace-indented hosts line",
+			content: "   hosts:   mymachines   resolve   [!UNAVAIL=return]   files   dns\n",
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "nsswitch.conf")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write temp nsswitch: %v", err)
+			}
+
+			orig := nsswitchPath
+			nsswitchPath = path
+			defer func() { nsswitchPath = orig }()
+
+			if got := nsswitchPrefersResolved(); got != tc.want {
+				t.Errorf("nsswitchPrefersResolved() = %v, want %v\ncontent:\n%s", got, tc.want, tc.content)
+			}
+		})
+	}
+}
+
+func TestNsswitchPrefersResolved_MissingFile(t *testing.T) {
+	orig := nsswitchPath
+	nsswitchPath = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { nsswitchPath = orig }()
+
+	if got := nsswitchPrefersResolved(); got != false {
+		t.Errorf("nsswitchPrefersResolved() on missing file = %v, want false", got)
+	}
+}


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

- On distributions whose `/etc/nsswitch.conf` hosts line consults `resolve` ahead of `dns` with `[!UNAVAIL=return]` (Arch Linux default, among others), writing `/etc/resolv.conf` via NetworkManager or resolvconf has no effect on hostname resolution — NSS asks systemd-resolved first, resolved has no DNS for the tunnel interface, and the action clause halts fallthrough to the `dns` service. Tunnel-only hostnames silently return NXDOMAIN.
- `DetectDNSManager` now checks the NSS hosts line and, when resolved dominates, returns `SystemdResolvedManager` so the existing D-Bus-based `SystemdResolvedDNSConfigurator` takes over (it already calls `SetDNS` / `SetDomains(".", MatchOnly:true)` / `SetDefaultRoute(true)`, which is what's needed here).

Full reproduction, symptoms, and root-cause analysis are in #114.

## Changes

- `dns/platform/detect_unix.go`:
  - Add `nsswitchPrefersResolved()` that parses `/etc/nsswitch.conf`'s hosts line and returns true when `resolve` precedes `dns` or `dns` is absent (ignoring action clauses like `[!UNAVAIL=return]`).
  - In `DetectDNSManager`, consult it in the `NetworkManagerManager` and `ResolvconfManager` branches. When systemd-resolved is running **and** NSS routes through it, return `SystemdResolvedManager`.
- `dns/platform/detect_unix_test.go`: table-driven tests for `nsswitchPrefersResolved` covering the Arch default line, resolve-only, dns-only, reversed order, commented lines, indented lines, and missing file.

No new dependencies; no public API change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./dns/platform/...` (8 subtests for `nsswitchPrefersResolved`, all pass)
- [x] On-device: confirmed on Arch Linux that running `resolvectl dns <iface> 100.96.128.1` + `resolvectl domain <iface> '~<internal>'` restores resolution — i.e. the path this PR takes automatically
- [ ] Maintainer sanity-check on Debian/Ubuntu (classic `hosts: files dns`) and Fedora (systemd-resolved primary) to confirm no regression in the non-Arch cases

Closes #114