### PR TITLE
fix(peers): merge Aliases in handleWgPeerUpdate

### DIFF
--- a/olm/peer.go
+++ b/olm/peer.go
@@ -189,6 +189,9 @@ func (o *Olm) handleWgPeerUpdate(msg websocket.WSMessage) {
 	if updateData.RemoteSubnets != nil {
 		siteConfig.RemoteSubnets = updateData.RemoteSubnets
 	}
+	if updateData.Aliases != nil {
+		siteConfig.Aliases = updateData.Aliases
+	}
 
 	if err := pm.UpdatePeer(siteConfig); err != nil {
 		logger.Error("Failed to update peer: %v", err)


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

WireGuard update-peer messages now copy Aliases from the payload into the merged SiteConfig so UpdatePeer can refresh alias DNS records.

Fixes fosrl/olm#106

## How to test?

When you change an alias the update message should include all aliases to configure
