### PR TITLE
Always re-register on WebSocket reconnect

### DIFF
--- a/olm/olm.go
+++ b/olm/olm.go
@@ -432,18 +432,18 @@ func (o *Olm) StartTunnel(config TunnelConfig) {
 
 		o.apiServer.SetConnectionStatus(true)
 
-		if o.registered {
-			o.websocket.StartPingMonitor()
-
-			logger.Debug("Already registered, skipping registration")
-			return nil
-		}
-
 		// Check if tunnel is still running before starting registration
 		if !o.tunnelRunning {
 			logger.Debug("Tunnel is no longer running, skipping registration")
 			return nil
 		}
+
+		// Cancel any in-flight registration interval from a previous connection
+		if o.stopRegister != nil {
+			o.stopRegister()
+			o.stopRegister = nil
+		}
+		o.registered = false
 
 		publicKey := o.privateKey.PublicKey()
 
@@ -456,23 +456,21 @@ func (o *Olm) StartTunnel(config TunnelConfig) {
 			return nil
 		}
 
-		if o.stopRegister == nil {
-			logger.Debug("Sending registration message to server with public key: %s and relay: %v", publicKey, !config.Holepunch)
-			o.stopRegister, o.updateRegister = o.websocket.SendMessageInterval("olm/wg/register", map[string]any{
-				"publicKey":   publicKey.String(),
-				"relay":       !config.Holepunch,
-				"olmVersion":  o.olmConfig.Version,
-				"olmAgent":    o.olmConfig.Agent,
-				"orgId":       config.OrgID,
-				"userToken":   userToken,
-				"fingerprint": o.fingerprint,
-				"postures":    o.postures,
-			}, 2*time.Second, 20)
+		logger.Debug("Sending registration message to server with public key: %s and relay: %v", publicKey, !config.Holepunch)
+		o.stopRegister, o.updateRegister = o.websocket.SendMessageInterval("olm/wg/register", map[string]any{
+			"publicKey":   publicKey.String(),
+			"relay":       !config.Holepunch,
+			"olmVersion":  o.olmConfig.Version,
+			"olmAgent":    o.olmConfig.Agent,
+			"orgId":       config.OrgID,
+			"userToken":   userToken,
+			"fingerprint": o.fingerprint,
+			"postures":    o.postures,
+		}, 2*time.Second, 20)
 
-			// Invoke onRegistered callback if configured
-			if o.olmConfig.OnRegistered != nil {
-				go o.olmConfig.OnRegistered()
-			}
+		// Invoke onRegistered callback if configured
+		if o.olmConfig.OnRegistered != nil {
+			go o.olmConfig.OnRegistered()
 		}
 
 		return nil


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

### Preface

This PR was developed with Claude Code (claude-opus-4-6). I identified the bug through live debugging of a broken Olm tunnel after a Pangolin server restart, traced the root cause through the code, and directed the fix. Claude wrote the patch. I reviewed and validated all changes.

## Description

After a Pangolin server restart (or any WebSocket disconnect/reconnect cycle), Olm clients fail to re-register with the server, leaving the WireGuard tunnel broken. The user must manually disconnect and reconnect to restore connectivity.

**Root cause:** The `OnConnect` callback in `StartTunnel` checks `o.registered` and returns early if it is `true`. However, `o.registered` is only reset to `false` by `StopTunnel()`. When the WebSocket reconnects (server restart, network interruption), the callback fires again but `o.registered` is still `true` from the previous connection, so registration is skipped entirely.

The server has lost all in-memory state (including `clientConfigVersions` and the client's WireGuard peer entry), so the client *must* re-register to restore the tunnel. Skipping registration leaves the client in a state where it believes it is registered but the server has no record of it.

**Fix:** Remove the `o.registered` early-return guard and always re-register on reconnect. Cancel any in-flight `SendMessageInterval` from a previous connection before starting a new one.

Related issues: #7, #72, #108

Companion PR: fosrl/pangolin#3069

## How to test?

1. Connect an Olm client to a Pangolin server with at least one site configured.
2. Verify the tunnel works (access a resource through the tunnel).
3. Restart the Pangolin server (`docker restart pangolin`).
4. Wait for the Olm client to reconnect (watch logs for "Websocket Connected").
5. **Before fix:** Client logs "Already registered, skipping registration" and the tunnel is broken.
6. **After fix:** Client re-registers, receives site configurations, and the tunnel recovers automatically.