### PR TITLE
fix: create nm conf directory if missing

### DIFF
--- a/dns/platform/network_manager.go
+++ b/dns/platform/network_manager.go
@@ -59,9 +59,12 @@ func NewNetworkManagerDNSConfigurator(ifaceName string) (*NetworkManagerDNSConfi
 		return nil, fmt.Errorf("interface name is required")
 	}
 
-	// Check that NetworkManager conf.d directory exists
-	if _, err := os.Stat(networkManagerConfDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("NetworkManager conf.d directory not found: %s", networkManagerConfDir)
+	// NetworkManager scans conf.d for drop-in config files even if the
+	// directory wasn't pre-created by the package (seen on minimal/container
+	// installs). Create it rather than failing, since NM already picks up
+	// files placed there without any further configuration.
+	if err := os.MkdirAll(networkManagerConfDir, 0755); err != nil {
+		return nil, fmt.Errorf("create NetworkManager conf.d directory: %w", err)
 	}
 
 	configurator := &NetworkManagerDNSConfigurator{


### PR DESCRIPTION
fixes #136

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

NewNetworkManagerDNSConfigurator returned an error whenever /etc/NetworkManager/conf.d didn't exist, instead of creating it. NetworkManager scans that directory for drop-in .conf files unconditionally. A missing directory doesn't mean NetworkManager can't be configured this way, it usually just means the distro/image didn't ship an empty dir. (for example on my Voidlinux installation)

## How to test?

1. On a Linux box with NetworkManager active (nmcli works / dbus reachable):
sudo rm -rf /etc/NetworkManager/conf.d
2. Run olm with DNS override enabled (e.g. pangolin up).
3. Confirm:
  - /etc/NetworkManager/conf.d/olm-dns.conf now exists, containing olm's proxy IP.
4. Stop the tunnel (pangolin down / SIGTERM) and confirm:
  - olm-dns.conf is removed.
  - NetworkManager is reloaded and original DNS is restored.